### PR TITLE
お気に入りバス停を登録する機能 / UI を作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 
 import 'services_locator.dart';
 import './service/navigation.dart';
-import './ui/login/login.dart';
+import 'ui/start_up/start_up_view.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -43,6 +43,6 @@ class MyApp extends StatelessWidget {
         theme: appTheme,
         navigatorKey: _navigation.navigatorKey,
         onGenerateRoute: NavigationService.generateRoute,
-        home: LoginView());
+        initialRoute: StartUpView.routeName);
   }
 }

--- a/lib/model/bus_pair.dart
+++ b/lib/model/bus_pair.dart
@@ -19,4 +19,6 @@ class BusPair {
       second: data['second'] as String,
     );
   }
+
+  Map<String, String> toDict() => {"first": first, "second": second};
 }

--- a/lib/service/authentication.dart
+++ b/lib/service/authentication.dart
@@ -21,7 +21,11 @@ class AuthService {
   Stream<User?> get user => _firebaseAuth.userChanges();
 
   /// user's uid
-  String? get uid => _firebaseAuth.currentUser?.uid;
+  Map<String, String?> get userProfile => {
+        "uid": _firebaseAuth.currentUser?.uid,
+        "displayName": _firebaseAuth.currentUser?.displayName,
+        "photoURL": _firebaseAuth.currentUser?.photoURL,
+      };
 
   /// sign in to Firebase Authentication Service with Google
   Future<User?> signInWithGoogle() async {

--- a/lib/service/firestore_service.dart
+++ b/lib/service/firestore_service.dart
@@ -6,6 +6,7 @@ class FirestoreService {
   CollectionReference buses = FirebaseFirestore.instance.collection('buses');
   CollectionReference bus_pairs =
       FirebaseFirestore.instance.collection('bus_pairs');
+  CollectionReference users = FirebaseFirestore.instance.collection('users');
 
   // [ Timetabel, Timetable, ... ]
   Future<List<Timetable>> getTargetTimetables(
@@ -30,5 +31,27 @@ class FirestoreService {
   Future<List<BusPair>> getBusPairs() async {
     return await bus_pairs.get().then((QuerySnapshot querySnapshot) =>
         querySnapshot.docs.map((doc) => BusPair.fromFirestore(doc)).toList());
+  }
+
+  // ユーザーごとのバス停組み合わせ一覧を取得
+  Future<List<BusPair>> getUserBusPairs(String uid) async {
+    return await users.doc(uid).collection("bus_pairs").get().then(
+        (QuerySnapshot querySnapshot) => querySnapshot.docs
+            .map((doc) => BusPair.fromFirestore(doc))
+            .toList());
+  }
+
+  // ユーザーごとのバス停組み合わせを作成
+  Future<void> setUserBusPair(String uid, BusPair busPair) async {
+    await users
+        .doc(uid)
+        .collection("bus_pairs")
+        .doc(busPair.id)
+        .set(busPair.toDict());
+  }
+
+  // ユーザーごとのバス停組み合わせを削除
+  Future<void> removeUserBusPair(String uid, BusPair busPair) async {
+    await users.doc(uid).collection("bus_pairs").doc(busPair.id).delete();
   }
 }

--- a/lib/service/navigation.dart
+++ b/lib/service/navigation.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+
 import '../ui/home/home_view.dart';
 import '../ui/login/login.dart';
+import '../ui/start_up/start_up_view.dart';
 
 class NavigationService {
   /// Navigator を指定するキー
@@ -31,7 +33,7 @@ class NavigationService {
       case LoginView.routeName:
         return MaterialPageRoute(builder: (_) => LoginView());
       default:
-        return MaterialPageRoute(builder: (_) => LoginView());
+        return MaterialPageRoute(builder: (_) => StartUpView());
     }
   }
 }

--- a/lib/ui/favorite/select_favorite.dart
+++ b/lib/ui/favorite/select_favorite.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:trainkun/service/navigation.dart';
+import 'package:trainkun/ui/home/home_view.dart';
 import '../../services_locator.dart';
 import '../home/home_viewmodel.dart';
 import '../../model/bus_pair.dart';
 
-class FavoriteWidget extends StatelessWidget {
+// 全てのバス停からお気に入りのバス停を選択
+class SelectFavoriteWidget extends StatelessWidget {
   final HomeViewModel model;
-  const FavoriteWidget({Key? key, required this.model}) : super(key: key);
+  const SelectFavoriteWidget({Key? key, required this.model}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -19,10 +21,9 @@ class FavoriteWidget extends StatelessWidget {
             color: Theme.of(context).primaryColor,
           ),
           child: ListView.builder(
-            itemCount: model.favoriteBusPairs.length,
+            itemCount: model.busPairs.length,
             itemBuilder: (_, i) {
-              return BusPairCard(
-                  model: model, busPair: model.favoriteBusPairs[i]);
+              return BusPairCard(model: model, busPair: model.busPairs[i]);
             },
           ),
         ));
@@ -39,16 +40,20 @@ class BusPairCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final _navigation = servicesLocator<NavigationService>();
+    final isFavorite = model.isFavoriteBusPair(busPair);
 
     return Container(
       height: 70,
       child: Card(
           clipBehavior: Clip.antiAliasWithSaveLayer,
-          color: Theme.of(context).accentColor,
+          color: isFavorite ? Colors.blue : Theme.of(context).accentColor,
           child: new InkWell(
             onTap: () {
-              model.setBusPairFromFavorite(busPair);
-              _navigation.pop();
+              isFavorite
+                  ? model.removeBusPairFavorite(busPair)
+                  : model.setBusPairFavorite(busPair);
+              // TODO: 処理を変更
+              _navigation.pushNamed(routeName: HomeView.routeName);
             },
             child: Padding(
                 padding: EdgeInsets.fromLTRB(15, 0, 0, 0),
@@ -56,27 +61,31 @@ class BusPairCard extends StatelessWidget {
                   mainAxisSize: MainAxisSize.max,
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    _busRouteView(context, model, true),
-                    _busRouteView(context, model, false),
+                    _busRouteView(context, model, true, isFavorite),
+                    _busRouteView(context, model, false, isFavorite),
                   ],
                 )),
           )),
     );
   }
 
-  Widget _busRouteView(context, HomeViewModel model, bool isDepartute) {
+  Widget _busRouteView(
+      context, HomeViewModel model, bool isDepartute, bool isFavorite) {
     return Row(
       mainAxisSize: MainAxisSize.max,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
         Text(isDepartute ? "乗車: " : "降車: ",
-            style: Theme.of(context).textTheme.bodyText2),
+            style: isFavorite
+                ? Theme.of(context).textTheme.bodyText1
+                : Theme.of(context).textTheme.bodyText2),
         Padding(
           padding: EdgeInsets.fromLTRB(10, 0, 0, 0),
           child: Text(
-            (isDepartute ^ model.isReverse) ? busPair.first : busPair.second,
-            style: Theme.of(context).textTheme.bodyText2,
-          ),
+              (isDepartute ^ model.isReverse) ? busPair.first : busPair.second,
+              style: isFavorite
+                  ? Theme.of(context).textTheme.bodyText1
+                  : Theme.of(context).textTheme.bodyText2),
         )
       ],
     );

--- a/lib/ui/home/home_viewmodel.dart
+++ b/lib/ui/home/home_viewmodel.dart
@@ -45,7 +45,9 @@ class HomeViewModel extends BaseViewModel {
     notifyListeners();
   }
 
-  // 現在時刻 / 平日・土日 を設定
+  // =============================
+  // 現在時刻 / 平日・土日
+  // =============================
   setTime() async {
     // api: http://s-proj.com/utils/holiday.html
     Uri uri = Uri.parse("http://s-proj.com/utils/checkHoliday.php?kind=h");
@@ -72,6 +74,9 @@ class HomeViewModel extends BaseViewModel {
     }
   }
 
+  // =============================
+  // バス停/時刻表を変数に保存
+  // =============================
   Future<void> setBusPairs() async {
     busPairs = await _firestore.getBusPairs();
     // 初期値を登録
@@ -88,7 +93,9 @@ class HomeViewModel extends BaseViewModel {
         allTimetables.where((timetable) => timetable.isHoliday).toList();
   }
 
+  // =============================
   // バス停を選択
+  // =============================
   Future<void> setBusPairFromFavorite(BusPair busPair) async {
     origin = isReverse ? busPair.second : busPair.first;
     destination = isReverse ? busPair.first : busPair.second;
@@ -102,13 +109,18 @@ class HomeViewModel extends BaseViewModel {
     isReverse = !isReverse;
   }
 
+  // =============================
   // 時刻を現在時刻に変更 / 時刻表を更新
+  // =============================
   Future<void> onRefresh() async {
     await setTime();
     await setTimetables();
     notifyListeners();
   }
 
+  // =============================
+  // サインアウト
+  // =============================
   Future<void> signOut() async {
     await _auth.signOut();
     _navigation.pushNamed(routeName: LoginView.routeName);

--- a/lib/ui/login/login.dart
+++ b/lib/ui/login/login.dart
@@ -104,27 +104,16 @@ class LoginView extends StatelessWidget {
                                       ),
                                       Align(
                                         alignment: Alignment(-0.83, 0),
-                                        child: InkWell(
-                                          onTap: () async {
-                                            await Navigator.push(
-                                              context,
-                                              MaterialPageRoute(
-                                                builder: (context) =>
-                                                    HomeView(),
-                                              ),
-                                            );
-                                          },
-                                          child: Container(
-                                            width: 22,
-                                            height: 22,
-                                            clipBehavior: Clip.antiAlias,
-                                            decoration: BoxDecoration(
-                                              shape: BoxShape.circle,
-                                            ),
-                                            child: Image.network(
-                                              'https://i0.wp.com/nanophorm.com/wp-content/uploads/2018/04/google-logo-icon-PNG-Transparent-Background.png?w=1000&ssl=1',
-                                              fit: BoxFit.contain,
-                                            ),
+                                        child: Container(
+                                          width: 22,
+                                          height: 22,
+                                          clipBehavior: Clip.antiAlias,
+                                          decoration: BoxDecoration(
+                                            shape: BoxShape.circle,
+                                          ),
+                                          child: Image.network(
+                                            'https://i0.wp.com/nanophorm.com/wp-content/uploads/2018/04/google-logo-icon-PNG-Transparent-Background.png?w=1000&ssl=1',
+                                            fit: BoxFit.contain,
                                           ),
                                         ),
                                       )

--- a/lib/ui/login/login.dart
+++ b/lib/ui/login/login.dart
@@ -14,7 +14,6 @@ class LoginView extends StatelessWidget {
   Widget build(BuildContext context) {
     return ViewModelBuilder<LoginViewModel>.reactive(
         viewModelBuilder: () => LoginViewModel(),
-        onModelReady: (model) => model.initialize(),
         builder: (context, model, child) => model.isBusy
             ? Loading()
             : Scaffold(

--- a/lib/ui/login/login_viewmodel.dart
+++ b/lib/ui/login/login_viewmodel.dart
@@ -12,7 +12,6 @@ class LoginViewModel extends BaseViewModel {
   /// submitSignInForm
   void signInWithGoogle() async {
     setBusy(true);
-    notifyListeners();
     await _auth.signInWithGoogle();
 
     _navigation.pushNamed(routeName: HomeView.routeName);

--- a/lib/ui/login/login_viewmodel.dart
+++ b/lib/ui/login/login_viewmodel.dart
@@ -9,14 +9,6 @@ class LoginViewModel extends BaseViewModel {
   final _navigation = servicesLocator<NavigationService>();
   final _auth = servicesLocator<AuthService>();
 
-  void initialize() async {
-    setBusy(true);
-    if (_auth.uid != null) {
-      _navigation.pushNamed(routeName: HomeView.routeName);
-    }
-    setBusy(false);
-  }
-
   /// submitSignInForm
   void signInWithGoogle() async {
     setBusy(true);

--- a/lib/ui/start_up/start_up_view.dart
+++ b/lib/ui/start_up/start_up_view.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+
+import '../../shared/loading.dart';
+import 'start_up_viewmodel.dart';
+
+class StartUpView extends StatelessWidget {
+  ///
+  static const routeName = '/';
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<StartUpViewModel>.reactive(
+      viewModelBuilder: () => StartUpViewModel(),
+      onModelReady: (model) => model.handleStartUpLogic(),
+      builder: (content, model, child) => Loading(),
+    );
+  }
+}

--- a/lib/ui/start_up/start_up_viewmodel.dart
+++ b/lib/ui/start_up/start_up_viewmodel.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:stacked/stacked.dart';
 
 import '../../services_locator.dart';
@@ -12,10 +13,12 @@ class StartUpViewModel extends BaseViewModel {
   final _auth = servicesLocator<AuthService>();
 
   Future handleStartUpLogic() async {
-    if (_auth.uid != null) {
-      _navigation.pushNamed(routeName: HomeView.routeName);
-    } else {
-      _navigation.pushNamed(routeName: LoginView.routeName);
-    }
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      if (_auth.uid != null) {
+        _navigation.pushNamed(routeName: HomeView.routeName);
+      } else {
+        _navigation.pushNamed(routeName: LoginView.routeName);
+      }
+    });
   }
 }

--- a/lib/ui/start_up/start_up_viewmodel.dart
+++ b/lib/ui/start_up/start_up_viewmodel.dart
@@ -1,0 +1,21 @@
+import 'package:stacked/stacked.dart';
+
+import '../../services_locator.dart';
+import '../../service/authentication.dart';
+import '../../service/navigation.dart';
+import '../../ui/home/home_view.dart';
+import '../../ui/login/login.dart';
+
+///
+class StartUpViewModel extends BaseViewModel {
+  final _navigation = servicesLocator<NavigationService>();
+  final _auth = servicesLocator<AuthService>();
+
+  Future handleStartUpLogic() async {
+    if (_auth.uid != null) {
+      _navigation.pushNamed(routeName: HomeView.routeName);
+    } else {
+      _navigation.pushNamed(routeName: LoginView.routeName);
+    }
+  }
+}

--- a/lib/ui/start_up/start_up_viewmodel.dart
+++ b/lib/ui/start_up/start_up_viewmodel.dart
@@ -14,7 +14,7 @@ class StartUpViewModel extends BaseViewModel {
 
   Future handleStartUpLogic() async {
     WidgetsBinding.instance!.addPostFrameCallback((_) {
-      if (_auth.uid != null) {
+      if (_auth.userProfile["uid"] != null) {
         _navigation.pushNamed(routeName: HomeView.routeName);
       } else {
         _navigation.pushNamed(routeName: LoginView.routeName);


### PR DESCRIPTION
## 概要
ログイン機能を利用して，
お気に入りのバス停登録機能を作成した

## 技術的な詳細
* アプリ起動後に遷移する画面を `StartUpView` に変更し，ログイン状態に応じて `LoginView`・`HomeView` に遷移
* すべてのバス停を持つ `busPairs` と お気に入りのバス停を持つ `favoriteBusPairs` に分けて保存

## 確認画面
<img width="25%" alt="スクリーンショット 2021-09-12 0 04 10" src="https://user-images.githubusercontent.com/51741264/132952236-d314b2fe-99d8-4c91-8d27-25ab56e3d610.png"><img width="25%" alt="スクリーンショット 2021-09-12 0 04 00" src="https://user-images.githubusercontent.com/51741264/132952229-8b3e16a8-0ebe-4c42-8093-d7f227f6cceb.png"><img width="25%" alt="スクリーンショット 2021-09-12 0 04 18" src="https://user-images.githubusercontent.com/51741264/132952243-56a30249-0e9d-4667-bc71-52b2009e7b09.png">

## TODO
* デフォルト値を決めれるようにする
* 全体的にエラーハンドリング
* お気に入り選択後に画面を遷移せずに変更できるようにする